### PR TITLE
feat: add RabbitMQConfig & Communication for memberAdded

### DIFF
--- a/CommunitiesService/pom.xml
+++ b/CommunitiesService/pom.xml
@@ -93,6 +93,10 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/controllers/CommunicationTestController.java
+++ b/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/controllers/CommunicationTestController.java
@@ -1,0 +1,29 @@
+// This file is for testing leave until we finish all the communication.
+
+
+//package com.example.reddit.CommunitiesService.controllers;
+//
+//import com.example.reddit.CommunitiesService.models.Community;
+//import com.example.reddit.CommunitiesService.rabbitmq.CommunityProducer;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.web.bind.annotation.*;
+//import java.util.List;
+//import java.util.UUID;
+//
+//@RestController
+//@RequestMapping("/api/test/communities")
+//public class CommunicationTestController {
+//    private final CommunityProducer communityProducer;
+//
+//    @Autowired
+//    public CommunicationTestController(CommunityProducer communityProducer) {
+//        this.communityProducer = communityProducer;
+//    }
+//
+//    @GetMapping
+//    public void test() {
+//        UUID communityId = UUID.randomUUID();
+//        communityProducer.notifyMemberAdded(communityId);
+//    }
+//
+//}

--- a/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/models/MemberDTO.java
+++ b/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/models/MemberDTO.java
@@ -1,0 +1,20 @@
+package com.example.reddit.CommunitiesService.models;
+
+import java.util.UUID;
+
+public class MemberDTO {
+    private UUID id;
+
+    public MemberDTO() {}
+    public MemberDTO(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+}

--- a/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/rabbitmq/CommunityProducer.java
+++ b/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/rabbitmq/CommunityProducer.java
@@ -1,0 +1,27 @@
+package com.example.reddit.CommunitiesService.rabbitmq;
+
+import com.example.reddit.CommunitiesService.models.MemberDTO;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class CommunityProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public CommunityProducer(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void notifyMemberAdded(UUID userID){
+        MemberDTO memberDTO = new MemberDTO(userID);
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.EXCHANGE,
+                "community.memberAdded",
+                memberDTO
+        );
+
+        System.out.println("User ID: " + memberDTO.getId() + " sent ");
+    }
+}

--- a/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/rabbitmq/RabbitMQConfig.java
+++ b/CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/rabbitmq/RabbitMQConfig.java
@@ -1,0 +1,67 @@
+package com.example.reddit.CommunitiesService.rabbitmq;
+
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.DefaultJackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Configuration
+public class RabbitMQConfig {
+//    public static final String COMMUNITY_QUEUE = "community_queue";
+    public static final String EXCHANGE = "community_exchange";
+//    public static final String COMMUNITY_ROUTING = "community_routing";
+
+//    @Bean
+//    public Queue queue(){
+//        return new Queue(COMMUNITY_QUEUE);
+//    }
+
+    @Bean
+    public TopicExchange exchange(){
+        return new TopicExchange(EXCHANGE);
+    }
+
+//    @Bean
+//    public Binding binding(Queue queue, TopicExchange exchange){
+//        return BindingBuilder.bind(queue).to(exchange).with(COMMUNITY_ROUTING);
+//    }
+
+    /** Convert your POJOs to JSON when sending */
+    @Bean
+    public Jackson2JsonMessageConverter messageConverter() {
+        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter();
+
+        // 1. Create a type-mapper and tell it which simple IDs map to which classes:
+        DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
+        Map<String, Class<?>> idToClass = new HashMap<>();
+        idToClass.put("MemberDTO",    com.example.reddit.CommunitiesService.models.MemberDTO.class);
+
+        // …add any other event/DTO types you need
+        typeMapper.setIdClassMapping(idToClass);
+
+        // 2. Tell it to use those IDs instead of the FQN
+        typeMapper.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.TYPE_ID);
+
+        converter.setJavaTypeMapper(typeMapper);
+        return converter;
+
+    }
+
+    /** Expose a RabbitTemplate that uses JSON conversion */
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory cf, Jackson2JsonMessageConverter converter) {
+        RabbitTemplate tpl = new RabbitTemplate(cf);
+        tpl.setMessageConverter(converter);
+        return tpl;
+    }
+
+
+}


### PR DESCRIPTION
This pull request introduces RabbitMQ integration into the `CommunitiesService` to enable event-driven communication. The changes include adding a RabbitMQ configuration, a producer for sending messages, and a new DTO class for message payloads. Additionally, a dependency for RabbitMQ was added to the `pom.xml` file.

### RabbitMQ Integration:

* **Added RabbitMQ Configuration**: Introduced `RabbitMQConfig` to define a `TopicExchange`, a JSON message converter, and a `RabbitTemplate` for sending messages. This enables the service to send messages in a structured JSON format. (`CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/rabbitmq/RabbitMQConfig.java`)
* **Created Message Producer**: Added `CommunityProducer` to send `MemberDTO` messages to the RabbitMQ exchange when a new member is added. (`CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/rabbitmq/CommunityProducer.java`)

### Data Transfer Object:

* **Introduced `MemberDTO`**: Created a simple DTO class to represent member data (UUID) for RabbitMQ messages. (`CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/models/MemberDTO.java`)

### Dependency Updates:

* **Added RabbitMQ Dependency**: Updated `pom.xml` to include the `spring-boot-starter-amqp` dependency for RabbitMQ support. (`CommunitiesService/pom.xml`)

### Miscellaneous:

* **Temporary Test Controller**: Added a commented-out `CommunicationTestController` for testing RabbitMQ communication. This is marked as temporary and should be removed once testing is complete. (`CommunitiesService/src/main/java/com/example/reddit/CommunitiesService/controllers/CommunicationTestController.java`)