### PR TITLE
feat: Add cascading delete behavior for User relationships in Block a…

### DIFF
--- a/user-service/src/main/java/com/redditclone/user_service/models/Block.java
+++ b/user-service/src/main/java/com/redditclone/user_service/models/Block.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor
@@ -22,10 +24,12 @@ public class Block {
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "blocker_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User blocker;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "blocked_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User blocked;
 
     public Block(User blocker, User blocked) {

--- a/user-service/src/main/java/com/redditclone/user_service/models/User.java
+++ b/user-service/src/main/java/com/redditclone/user_service/models/User.java
@@ -38,10 +38,13 @@ public class User implements UserDetails {
     private boolean activated;
 
     private String bio;
+
+    @NotBlank(message = "Full name is required")
     private String fullName;
+
     private Instant lastLogin;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefreshToken> refreshTokens;
 
     public User(String username, String password, String email, Instant createdAt, boolean activated) {

--- a/user-service/src/main/java/com/redditclone/user_service/models/VerificationToken.java
+++ b/user-service/src/main/java/com/redditclone/user_service/models/VerificationToken.java
@@ -2,6 +2,8 @@ package com.redditclone.user_service.models;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.Instant;
 
@@ -18,7 +20,8 @@ public class VerificationToken {
     private String token;
     private Instant expiryDate;
     @OneToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     public VerificationToken(String token, User user) {


### PR DESCRIPTION
This pull request introduces enhancements to the `user-service` module to improve data integrity and cascade behavior in entity relationships. The most important changes include adding `@OnDelete` annotations for cascading delete actions, enforcing constraints on fields, and refining entity relationships with `cascade` and `orphanRemoval` configurations.

### Cascade Behavior Enhancements:
* Added `@OnDelete(action = OnDeleteAction.CASCADE)` annotations to the `blocker` and `blocked` fields in the `Block` entity to ensure related `User` entities are properly handled during deletion. (`user-service/src/main/java/com/redditclone/user_service/models/Block.java`, [user-service/src/main/java/com/redditclone/user_service/models/Block.javaR27-R32](diffhunk://#diff-186980fc4f5e20f3c538a0419cea023cc54e1845ac5b3f9130e76fb1d5b13af6R27-R32))
* Updated the `user` field in the `VerificationToken` entity to include `@OnDelete(action = OnDeleteAction.CASCADE)` and made the `user_id` column non-nullable for stricter relationship enforcement. 

### Entity Relationship Improvements:
* Modified the `refreshTokens` field in the `User` entity to include `cascade = CascadeType.ALL` and `orphanRemoval = true`, ensuring proper cascading and cleanup of associated `RefreshToken` entities. 

### Field Validation:
* Added `@NotBlank` validation to the `fullName` field in the `User` entity to ensure the field is always populated.

### General Improvements:
* Imported necessary Hibernate annotations (`@OnDelete` and `@OnDeleteAction`) in the `Block` and `VerificationToken` entities to support the new cascading behavior. 