### PR TITLE
feat: add k8s files for user and postgres

### DIFF
--- a/k8s/user/postgres-secret.yaml
+++ b/k8s/user/postgres-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+data:
+  POSTGRES_USER: cG9zdGdyZXM=       # base64 for "postgres"
+  POSTGRES_PASSWORD: MTIzNA==  # base64 for "1234"
+  POSTGRES_DB: dXNlcl9zZXJ2aWNl   # base64 for "user_service"

--- a/k8s/user/postgres-service.yaml
+++ b/k8s/user/postgres-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  clusterIP: None  # Headless service
+  selector:
+    app: postgres

--- a/k8s/user/postgres-stateful.yaml
+++ b/k8s/user/postgres-stateful.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: postgres-persistent-storage
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-persistent-storage
+      spec:
+        accessModes: [ "ReadWriteOnce" ] # only one Pod (one node) can mount this volume as read/write at a time,” which is perfect for a single-instance database.
+        resources:
+          requests:
+            storage: 1Gi # This is how much disk space you’re asking for. The underlying storage class will provision a volume of at least this size

--- a/k8s/user/user-deployment.yaml
+++ b/k8s/user/user-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: user-service
+  template:
+    metadata:
+      labels:
+        app: user-service
+    spec:
+      containers:
+        - name: user-service
+          image: alyraafat/user-service:latest
+          ports:
+            - containerPort: 8080
+          env:
+            # Load the "dev" profile so Spring reads dev.yml overrides
+            - name: SPRING_PROFILES_ACTIVE
+              value: dev
+
+            # Point at your Postgres headless Service:
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://postgres:5432/user_service
+
+            # Pull username & password from the Secret:
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+

--- a/k8s/user/user-service.yaml
+++ b/k8s/user/user-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  labels:
+    app: user-service
+spec:
+  type: ClusterIP
+  selector:
+    app: user-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+


### PR DESCRIPTION
This pull request introduces Kubernetes configurations for deploying a PostgreSQL database and a `user-service` application. The changes include the creation of secrets, services, a StatefulSet for PostgreSQL, and a deployment for the `user-service`. These configurations enable a seamless integration between the application and the database.

### PostgreSQL Configuration:
* Added a Kubernetes `Secret` to store PostgreSQL credentials (`POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`) in base64-encoded format (`k8s/user/postgres-secret.yaml`).
* Created a headless `Service` for PostgreSQL to enable communication between the StatefulSet and the database (`k8s/user/postgres-service.yaml`).
* Defined a `StatefulSet` for PostgreSQL with persistent storage and environment variables sourced from the `Secret` (`k8s/user/postgres-stateful.yaml`).

### User-Service Configuration:
* Added a `Deployment` for the `user-service` application with two replicas, configured to connect to the PostgreSQL database using credentials from the `Secret` (`k8s/user/user-deployment.yaml`).
* Created a `ClusterIP` `Service` for the `user-service` to expose it internally within the cluster (`k8s/user/user-service.yaml`).
[Copilot is generating a summary...]