### PR TITLE
feat: add k8s deployment config for rabbitmq and redis

### DIFF
--- a/k8s/rabbitmq/rabbitmq-deployment.yaml
+++ b/k8s/rabbitmq/rabbitmq-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:4-management
+          ports:
+            - containerPort: 5672  # AMQP port
+            - containerPort: 15672 # Management UI port
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-secret
+                  key: RABBITMQ_DEFAULT_USER
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-secret
+                  key: RABBITMQ_DEFAULT_PASS

--- a/k8s/rabbitmq/rabbitmq-secret.yaml
+++ b/k8s/rabbitmq/rabbitmq-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-secret
+type: Opaque
+data:
+  RABBITMQ_DEFAULT_USER: Z3Vlc3Q=     # base64 for "guest"
+  RABBITMQ_DEFAULT_PASS: Z3Vlc3Q=     # base64 for "guest"

--- a/k8s/rabbitmq/rabbitmq-service.yaml
+++ b/k8s/rabbitmq/rabbitmq-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+    - name: management
+      port: 15672
+      targetPort: 15672

--- a/k8s/redis/redis-deployment.yaml
+++ b/k8s/redis/redis-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis
+          ports:
+            - containerPort: 6379

--- a/k8s/redis/redis-service.yaml
+++ b/k8s/redis/redis-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379


### PR DESCRIPTION
This pull request introduces Kubernetes configurations for deploying RabbitMQ and Redis services. It includes deployment, service, and secret configurations to enable these applications to run in a Kubernetes cluster.

### RabbitMQ Configuration:

* [`k8s/rabbitmq/rabbitmq-deployment.yaml`](diffhunk://#diff-b12385d0a4661a2720ccd009fef9172590d4cae79aba9f4793ed6d8e60788129R1-R31): Added a deployment configuration for RabbitMQ with one replica, exposing ports for AMQP (5672) and the management UI (15672). Environment variables for default credentials are sourced from a Kubernetes secret.
* [`k8s/rabbitmq/rabbitmq-secret.yaml`](diffhunk://#diff-e3a699551b08cd0f4426bf9c9d41ab1807dd6ba0fcd6e3f69fcc13b4bce67198R1-R8): Added a Kubernetes secret to store the default RabbitMQ username and password, encoded in base64.
* [`k8s/rabbitmq/rabbitmq-service.yaml`](diffhunk://#diff-a4751db186453847822391bb659662bdeaa70f27b93c836572cb34d34617bc51R1-R14): Added a service configuration to expose RabbitMQ's AMQP and management UI ports.

### Redis Configuration:

* [`k8s/redis/redis-deployment.yaml`](diffhunk://#diff-6b8a3997ae43841b9f60ad2e27ac90ead27eca15e1291c62a6e3230fea357b95R1-R19): Added a deployment configuration for Redis with one replica, exposing the default Redis port (6379).
* [`k8s/redis/redis-service.yaml`](diffhunk://#diff-4603aec3a6a1b57f9dadf617172ad071bf9f9fbd8660a6fe0399c9036d992debR1-R10): Added a service configuration to expose Redis on port 6379.