### PR TITLE
feat: add k8s file for notification service

### DIFF
--- a/k8s/notification/mongo-notification-service.yaml
+++ b/k8s/notification/mongo-notification-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo-notification
+spec:
+  clusterIP: None          
+  selector:
+    app: mongo-notification
+  ports:
+    - name: mongo
+      port: 27017
+      targetPort: 27017

--- a/k8s/notification/mongo-notification-stateful.yaml
+++ b/k8s/notification/mongo-notification-stateful.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongo-notification
+spec:
+  serviceName: mongo-notification
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongo-notification
+  template:
+    metadata:
+      labels:
+        app: mongo-notification
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:latest        
+          ports:
+            - name: mongo
+              containerPort: 27017
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-notification-secret
+                  key: MONGO_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-notification-secret
+                  key: MONGO_ROOT_PASSWORD
+          volumeMounts:
+            - name: mongo-data
+              mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: mongo-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/notification/notification-deployment.yaml
+++ b/k8s/notification/notification-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: notification-service
+  template:
+    metadata:
+      labels:
+        app: notification-service
+    spec:
+      containers:
+        - name: notification-service
+          image: redditclone/notification-service:latest
+          ports:
+            - containerPort: 9090
+          env:
+            - name: SPRING_DATA_MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: notification-secrets
+                  key: MONGODB_URI
+            - name: SPRING_DATA_MONGODB_DATABASE
+              value: notification_service_mongo
+
+            - name: SPRING_RABBITMQ_HOST
+              value: rabbitmq
+            - name: SPRING_RABBITMQ_PORT
+              value: "5672"
+            - name: SPRING_RABBITMQ_USERNAME
+              value: guest
+            - name: SPRING_RABBITMQ_PASSWORD
+              value: guest
+
+            - name: SENDGRID_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: notification-secrets
+                  key: SENDGRID_API_KEY
+            - name: SENDGRID_SENDER_EMAIL
+              value: emailnotificationsapp@gmail.com

--- a/k8s/notification/notification-secret.yaml
+++ b/k8s/notification/notification-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: notification-secrets
+type: Opaque
+data:
+  MONGODB_URI: bW9uZ29kYjovL3Jvb3Q6ZXhhbXBsZUBtb25nby1ub3RpZmljYXRpb246MjcwMTcvbm90aWZpY2F0aW9uX3NlcnZpY2VfbW9uZ28/YXV0aFNvdXJjZT1hZG1pbg==
+  SENDGRID_API_KEY: U0cuNlRGTklDcm9SSU80QVZCZWg3aTJPUS5pQkRhWU92ZEJBQXhBZkJGaTEyNURiRXBfME9hdXFEN3dQNWc4STkwdzRJ

--- a/k8s/notification/notification-service.yaml
+++ b/k8s/notification/notification-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090 
+  type: ClusterIP

--- a/k8s/secrets/mongo-secret.yaml
+++ b/k8s/secrets/mongo-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongo-notification-secret
+type: Opaque
+data:
+  MONGO_ROOT_USERNAME: cm9vdA== #root
+  MONGO_ROOT_PASSWORD: ZXhhbXBsZQ== #example


### PR DESCRIPTION
This pull request introduces Kubernetes configurations to deploy a notification service and its dependencies, including MongoDB and RabbitMQ. The changes include the addition of StatefulSets, Deployments, Services, and Secrets to set up the required infrastructure.

### MongoDB Setup:
* Added a `StatefulSet` for MongoDB with persistent storage (`mongo-notification-stateful.yaml`). It uses a `mongo:latest` image, initializes credentials from a secret, and requests 5Gi of storage.
* Added a headless `Service` to enable communication within the MongoDB StatefulSet (`mongo-notification-service.yaml`).
* Added a Kubernetes secret to store MongoDB credentials (`mongo-secret.yaml`).

### Notification Service Setup:
* Added a `Deployment` for the notification service with two replicas. It configures environment variables for MongoDB, RabbitMQ, and SendGrid integration, sourcing sensitive data from a secret (`notification-deployment.yaml`).
* Added a `ClusterIP` `Service` to expose the notification service within the cluster (`notification-service.yaml`).
* Added a Kubernetes secret to store credentials for MongoDB and SendGrid API (`notification-secret.yaml`).