### PR TITLE
Adding seeding data

### DIFF
--- a/user-service/src/main/java/com/redditclone/user_service/configs/DataSeeder.java
+++ b/user-service/src/main/java/com/redditclone/user_service/configs/DataSeeder.java
@@ -42,7 +42,9 @@ public class DataSeeder {
             @Transactional
             public void run(String... args) {
                 seedFixedNotificationUsers();
+                seedTestApiUsers();
                 seedFakeUsers();
+                seedTestBlockRelation();
                 seedBlocks();
             }
         };
@@ -130,4 +132,61 @@ public class DataSeeder {
             System.out.println("[DataSeeder] Blocks already seeded");
         }
     }
+    private void seedTestApiUsers() {
+        if (userRepository.findByUsername("apitest_active").isEmpty()) {
+            User activeUser = User.builder()
+                    .username("apitest_active")
+                    .password(passwordEncoder.encode("pass123"))
+                    .email("apitest_active@example.com")
+                    .fullName("Active API Test")
+                    .createdAt(Instant.now())
+                    .activated(true)
+                    .lastLogin(Instant.now())
+                    .build();
+            userRepository.save(activeUser);
+            System.out.println("[DataSeeder] Created user: apitest_active");
+        }
+
+        if (userRepository.findByUsername("apitest_blocked").isEmpty()) {
+            User blockedUser = User.builder()
+                    .username("apitest_blocked")
+                    .password(passwordEncoder.encode("pass123"))
+                    .email("apitest_blocked@example.com")
+                    .fullName("Blocked API Test")
+                    .createdAt(Instant.now())
+                    .activated(true)
+                    .lastLogin(Instant.now())
+                    .build();
+            userRepository.save(blockedUser);
+            System.out.println("[DataSeeder] Created user: apitest_blocked");
+        }
+        if (userRepository.findByUsername("apitest_blockedE2E").isEmpty()) {
+            User blockedUser = User.builder()
+                    .username("apitest_blockedE2E")
+                    .password(passwordEncoder.encode("pass123"))
+                    .email("apitest_blockedE2E@example.com")
+                    .fullName("Blocked API Test")
+                    .createdAt(Instant.now())
+                    .activated(true)
+                    .lastLogin(Instant.now())
+                    .build();
+            userRepository.save(blockedUser);
+            System.out.println("[DataSeeder] Created user: apitest_blockedE2E");
+        }
+    }
+
+    private void seedTestBlockRelation() {
+        User blocker = userRepository.findByUsername("apitest_active").orElse(null);
+        User blocked = userRepository.findByUsername("apitest_blocked").orElse(null);
+
+        if (blocker != null && blocked != null) {
+            Block b = Block.builder()
+                    .blocker(blocker)
+                    .blocked(blocked)
+                    .build();
+            blockRepository.save(b);
+            System.out.println("[DataSeeder] Blocked apitest_blocked by apitest_active");
+        }
+    }
+
 }


### PR DESCRIPTION
This pull request introduces new data seeding methods in the `DataSeeder` class of the `user-service` module to support testing scenarios for API and block relationships. The changes include adding test users and a block relationship between them.

### New data seeding methods:

* **`seedTestApiUsers` method**: Adds three test users (`apitest_active`, `apitest_blocked`, and `apitest_blockedE2E`) to the database if they do not already exist. These users are intended for API testing purposes.

* **`seedTestBlockRelation` method**: Creates a block relationship between the `apitest_active` user and the `apitest_blocked` user, enabling block-related testing scenarios.

### Integration into existing flow:

* Updated the `run` method to include calls to the new `seedTestApiUsers` and `seedTestBlockRelation` methods, ensuring these test entities are seeded during application startup.