### PR TITLE
feat: integrate SendGrid for email notifications and update mail conf…

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -151,6 +151,12 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.sendgrid</groupId>
+			<artifactId>sendgrid-java</artifactId>
+			<version>4.10.3</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/user-service/src/main/java/com/redditclone/user_service/services/MailService.java
+++ b/user-service/src/main/java/com/redditclone/user_service/services/MailService.java
@@ -1,23 +1,20 @@
 package com.redditclone.user_service.services;
 
-
-
 import com.redditclone.user_service.dtos.NotificationEmail;
 import com.redditclone.user_service.exceptions.RedditAppException;
-import jakarta.mail.Message;
-import jakarta.mail.internet.InternetAddress;
-import lombok.AllArgsConstructor;
+import com.sendgrid.*;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -25,10 +22,12 @@ import org.thymeleaf.context.Context;
 public class MailService {
 
     private final TemplateEngine templateEngine;
-    private final JavaMailSender mailSender;
 
-    @Value("${spring.mail.username}")
+    @Value("${sendgrid.sender.email}")
     private String sender;
+
+    @Value("${sendgrid.api.key}")
+    private String sendGridApiKey;
 
     String build(String message) {
         Context context = new Context();
@@ -38,21 +37,31 @@ public class MailService {
 
     @Async
     public void sendMail(NotificationEmail notificationEmail) {
-        MimeMessagePreparator messagePreparator = mimeMessage -> {
-            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
-            mimeMessage.setSender(new InternetAddress(sender));
-            mimeMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(notificationEmail.getRecipient()));
-            mimeMessage.setSubject(notificationEmail.getSubject());
-            messageHelper.setText(build(notificationEmail.getBody()), true);
-        };
+        String emailContent = build(notificationEmail.getBody());
 
-        try{
-            mailSender.send(messagePreparator);
-            log.info("Sent Activation email to {}", notificationEmail.getRecipient());
-        }
-        catch (MailException e){
+        Email from = new Email(sender);
+        Email to = new Email(notificationEmail.getRecipient());
+        Content content = new Content("text/html", emailContent);
+        Mail mail = new Mail(from, notificationEmail.getSubject(), to, content);
+
+        SendGrid sendGrid = new SendGrid(sendGridApiKey);
+        Request request = new Request();
+
+        try {
+            request.setMethod(Method.POST);
+            request.setEndpoint("mail/send");
+            request.setBody(mail.build());
+
+            Response response = sendGrid.api(request);
+            if (response.getStatusCode() != 202) {
+                log.error("Failed to send email. Status Code: {}, Response Body: {}", response.getStatusCode(), response.getBody());
+                throw new RedditAppException("SendGrid failed to send email.");
+            }
+
+            log.info("Sent email to {}", notificationEmail.getRecipient());
+        } catch (IOException e) {
+            log.error("SendGrid email sending failed", e);
             throw new RedditAppException("Exception occurred when sending mail to " + notificationEmail.getRecipient());
         }
-
     }
 }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -26,24 +26,24 @@ spring:
         format_sql: true
         use_sql_comments: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     generate-ddl: true
 
-# mail configuration
-  mail:
-    host: smtp.mailersend.net
-    port: 587
-    protocol: smtp
-    username: MS_b0d6XA@test-dnvo4d99we6g5r86.mlsender.net
-    password: mssp.KMpgRPL.ynrw7gyn7en42k8e.U2QK2IT
-    test-connection: true
-    properties:
-      "mail.smtp.auth": true
-      "mail.smtp.starttls.enable": true
-      "mail.smtp.starttls.required": true
-      "mail.smtp.socketFactory.class": javax.net.ssl.SSLSocketFactory
-      "mail.debug": true
+## mail configuration
+#  mail:
+#    host: smtp.mailersend.net
+#    port: 587
+#    protocol: smtp
+#    username: MS_b0d6XA@test-dnvo4d99we6g5r86.mlsender.net
+#    password: mssp.KMpgRPL.ynrw7gyn7en42k8e.U2QK2IT
+#    test-connection: true
+#    properties:
+#      "mail.smtp.auth": true
+#      "mail.smtp.starttls.enable": true
+#      "mail.smtp.starttls.required": true
+#      "mail.smtp.socketFactory.class": javax.net.ssl.SSLSocketFactory
+#      "mail.debug": true
 server:
   error:
     include-message: always
@@ -58,3 +58,8 @@ jwt:
     secret: "6d6a69b6c8ec760a83fe1296a593233e2a25f1ae04b1b59b4e401069ce1607697a7804fd1fa1ff0129a2964614645fdde4118a49d1b1d751e909583fe099c4f2fb41abccfab44a5d9b876984401682d606a4a9cc13d4329fb1bec25cf3f83fa46817f8f3e7610c00e1c277993f3151c9bdd8a003d2c01bdd5dd205941ac0b8f9cbcaf99affa88c982caaa4c417bcc9355c981e50d7b6d5ed0efca8c8a116e08ccc0de3907aa62b36e2a5929e6430b2d568f5be6a2172b7caf4628877fca133c9a1064c159e32c6563914dc1c23fa5146de84aa9eb575ac5f620da7132946245481a11893bd387a3cc7425623f1ab381f09c6e06111da757a9869545f79a94c54"
     expirationms: 600000 # 10 minutes
 
+sendgrid:
+  api:
+    key: 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
+  sender:
+    email: emailnotificationsapp@gmail.com


### PR DESCRIPTION
This pull request refactors the email functionality in the `user-service` module by replacing the existing JavaMailSender-based implementation with SendGrid. It also updates the application configuration to reflect this change and removes sensitive information from the configuration file.

### Email Service Refactor:
* Replaced the JavaMailSender-based email implementation with SendGrid in `MailService`. This includes using SendGrid's `Mail`, `Email`, and `Content` objects to construct and send emails, and handling API responses for error logging. (`user-service/src/main/java/com/redditclone/user_service/services/MailService.java`, [[1]](diffhunk://#diff-cb3ca522cd1899ae1dc82270a7a34d305319a8b0155eac6d9783543e268f3f23L3-R31) [[2]](diffhunk://#diff-cb3ca522cd1899ae1dc82270a7a34d305319a8b0155eac6d9783543e268f3f23L41-L56)
* Added the SendGrid dependency to `pom.xml` to enable the integration. (`user-service/pom.xml`, [user-service/pom.xmlR154-R159](diffhunk://#diff-8ec08ada4610a6e96e9613a2417ad376b00f9bd8a0926ec70623397d9b8c51b6R154-R159))

### Configuration Updates:
* Replaced the `spring.mail` configuration with `sendgrid` configuration in `application.yml`, including the API key and sender email. The old SMTP configuration is now commented out. (`user-service/src/main/resources/application.yml`, [[1]](diffhunk://#diff-59b4a102fc73a163bafa0a31dede85193cd3cb26f99bfe52a888032d953975cfL29-R46) [[2]](diffhunk://#diff-59b4a102fc73a163bafa0a31dede85193cd3cb26f99bfe52a888032d953975cfR61-R65)
* Changed the Hibernate `ddl-auto` setting from `update` to `create-drop` for database schema management during development. (`user-service/src/main/resources/application.yml`, [user-service/src/main/resources/application.ymlL29-R46](diffhunk://#diff-59b4a102fc73a163bafa0a31dede85193cd3cb26f99bfe52a888032d953975cfL29-R46))…iguration