### PR TITLE
refactor: update secret configurations to use stringData format in Ku…

### DIFF
--- a/k8s/community/community-secret.yaml
+++ b/k8s/community/community-secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: community-secrets
 type: Opaque
 stringData:
-  SPRING_DATA_MONGODB_URI: "mongodb://root:example@mongo:27017/communitiesDb?authSource=admin"
+  SPRING_DATA_MONGODB_URI: "mongodb://root:example@mongo-community:27017/communitiesDb?authSource=admin"

--- a/k8s/moderator/moderator-deployment.yaml
+++ b/k8s/moderator/moderator-deployment.yaml
@@ -34,11 +34,11 @@ spec:
                   key: POSTGRES_PASSWORD
             # RabbitMQ connection
             - name: SPRING_RABBITMQ_HOST
-              value: rabbitmq
+              value: "rabbitmq"
             - name: SPRING_RABBITMQ_PORT
               value: "5672"
             - name: SPRING_RABBITMQ_USERNAME
-              value: guest
+              value: "guest"
             - name: SPRING_RABBITMQ_PASSWORD
-              value: guest
+              value: "guest"
 

--- a/k8s/notification/notification-deployment.yaml
+++ b/k8s/notification/notification-deployment.yaml
@@ -41,11 +41,6 @@ spec:
                   name: rabbitmq-secret
                   key: RABBITMQ_DEFAULT_PASS
 
-            - name: SENDGRID_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: notification-secrets
-                  key: SENDGRID_API_KEY
             - name: SENDGRID_SENDER_EMAIL
               value: "emailnotificationsapp@gmail.com"
 

--- a/k8s/notification/notification-secret.yaml
+++ b/k8s/notification/notification-secret.yaml
@@ -3,6 +3,5 @@ kind: Secret
 metadata:
   name: notification-secrets
 type: Opaque
-data:
-  MONGODB_URI: bW9uZ29kYjovL3Jvb3Q6ZXhhbXBsZUBtb25nby1ub3RpZmljYXRpb246MjcwMTcvbm90aWZpY2F0aW9uX3NlcnZpY2VfbW9uZ28/YXV0aFNvdXJjZT1hZG1pbg==
-  SENDGRID_API_KEY: U0cuNlRGTklDcm9SSU80QVZCZWg3aTJPUS5pQkRhWU92ZEJBQXhBZkJGaTEyNURiRXBfME9hdXFEN3dQNWc4STkwdzRJ
+stringData:
+  MONGODB_URI: "mongodb://root:example@mongo-notification:27017/notification_service_mongo?authSource=admin"

--- a/k8s/secrets/mongo-secret.yaml
+++ b/k8s/secrets/mongo-secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: mongo-secret
 type: Opaque
-data:
-  MONGO_ROOT_USERNAME: cm9vdA== #root
-  MONGO_ROOT_PASSWORD: ZXhhbXBsZQ== #example
+stringData:
+  MONGO_ROOT_USERNAME: "root" #root
+  MONGO_ROOT_PASSWORD: "example" #example

--- a/k8s/secrets/postgres-secret.yaml
+++ b/k8s/secrets/postgres-secret.yaml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   name: postgres-secret
 type: Opaque
-data:
-  POSTGRES_USER: cG9zdGdyZXM=       # base64 for "postgres"
-  POSTGRES_PASSWORD: MTIzNA==  # base64 for "1234"
-  POSTGRES_USER_DB: dXNlcl9zZXJ2aWNl   # base64 for "user_service"
-  POSTGRES_MODERATOR_DB: bW9kZXJhdG9yX3NlcnZpY2UK # base64 for "moderator_service"
+stringData:
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "1234"
+  POSTGRES_USER_DB: "user_service"
+  POSTGRES_MODERATOR_DB: "moderator_service"

--- a/k8s/secrets/rabbitmq-secret.yaml
+++ b/k8s/secrets/rabbitmq-secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: rabbitmq-secret
 type: Opaque
-data:
-  RABBITMQ_DEFAULT_USER: Z3Vlc3Q=     # base64 for "guest"
-  RABBITMQ_DEFAULT_PASS: Z3Vlc3Q=     # base64 for "guest"
+stringData:
+  RABBITMQ_DEFAULT_USER: "guest"
+  RABBITMQ_DEFAULT_PASS: "guest"

--- a/k8s/thread/thread-secret.yaml
+++ b/k8s/thread/thread-secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: thread-secrets
 type: Opaque
 stringData:
-  SPRING_DATA_MONGODB_URI: "mongodb://root:example@mongo:27017/threadDb?authSource=admin"
+  SPRING_DATA_MONGODB_URI: "mongodb://root:example@mongo-thread:27017/threadDb?authSource=admin"


### PR DESCRIPTION
This pull request focuses on improving the configuration management of secrets and environment variables in Kubernetes manifests. The changes include replacing base64-encoded `data` fields with plaintext `stringData` fields for better readability and updating connection URIs and credentials for MongoDB, RabbitMQ, and PostgreSQL services.

### Secrets Management Updates:

* Replaced `data` fields with `stringData` in the following secret files for better readability:
  - `k8s/secrets/mongo-secret.yaml`
  - `k8s/secrets/postgres-secret.yaml`
  - `k8s/secrets/rabbitmq-secret.yaml`
  - `k8s/notification/notification-secret.yaml`

### Connection URI Updates:

* Updated MongoDB connection URIs to use service-specific hostnames:
  - [`k8s/community/community-secret.yaml`](diffhunk://#diff-0810cda5ee62c233ea494adac68c2f6f3410d76ee0f542e8b825ad150885e611L7-R7): Changed to `mongo-community`
  - [`k8s/thread/thread-secret.yaml`](diffhunk://#diff-4bb4cf0c7fd18115915c9226d605c47fa791a1b1396e892c04df4652090cb739L7-R7): Changed to `mongo-thread`
  - [`k8s/notification/notification-secret.yaml`](diffhunk://#diff-d097b0f2098814a4ad0cde3a4f3d37d3540752fdb321c1e2e1eb98ecdde4ba41L6-R7): Changed to `mongo-notification`

### Environment Variable Improvements:

* Standardized RabbitMQ environment variable values with explicit quotes for consistency in `k8s/moderator/moderator-deployment.yaml`.

### Cleanup:

* Removed unused `SENDGRID_API_KEY` environment variable from `k8s/notification/notification-deployment.yaml`.