### PR TITLE
feat: add RabbitMQ host configuration to user deployment

### DIFF
--- a/k8s/user/user-deployment.yaml
+++ b/k8s/user/user-deployment.yaml
@@ -45,3 +45,6 @@ spec:
             # JWT Configuration
             - name: JWT_EXPIRATION_MS
               value: "6000000000"
+
+            - name: SPRING_RABBITMQ_HOST
+              value: "rabbitmq"


### PR DESCRIPTION
This pull request updates the `k8s/user/user-deployment.yaml` file to include a new environment variable for RabbitMQ configuration.

* Added a new environment variable `SPRING_RABBITMQ_HOST` with the value `"rabbitmq"` to the `spec` section for RabbitMQ host configuration.