### PR TITLE
fix: update authorId assignment in ThreadService to use userId

### DIFF
--- a/ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.java
+++ b/ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.java
@@ -70,7 +70,7 @@ public class ThreadService {
                 .topic(thread.getTopic())
                 .title(thread.getTitle())
                 .content(thread.getContent())
-                .authorId(thread.getAuthorId())
+                .authorId(userId)
                 .createdAt(thread.getCreatedAt())
                 .upVotes(thread.getUpVotes() )
                 .downVotes(thread.getDownVotes())


### PR DESCRIPTION
This pull request includes a small but significant change to the `ThreadService.java` file. The change updates the `createThread` method to use the `userId` parameter as the `authorId` instead of relying on the `authorId` provided in the `thread` object. 

This ensures that the `authorId` is explicitly tied to the authenticated user creating the thread, improving data integrity.