### PR TITLE
update logs userid

### DIFF
--- a/ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.java
+++ b/ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.java
@@ -133,7 +133,7 @@ public class ThreadService {
 
         Thread saved = threadRepository.save(thread);
 
-        logReflectionFactory.createLog(ActionType.COMMENT, thread.getAuthorId(), saved.getId());
+        logReflectionFactory.createLog(ActionType.COMMENT, userId, saved.getId());
 
         threadProducer.sendThreadNotificationRequest(saved, "comment");
 
@@ -212,7 +212,7 @@ public class ThreadService {
                 .build();
         Thread saved = threadRepository.save(thread);
 
-        logReflectionFactory.createLog(ActionType.UPVOTE, thread.getAuthorId(), saved.getId());
+        logReflectionFactory.createLog(ActionType.UPVOTE, userId, saved.getId());
 
         threadProducer.sendThreadNotificationRequest(saved, "up");
 
@@ -243,7 +243,7 @@ public class ThreadService {
 
         Thread saved = threadRepository.save(thread);
 
-        logReflectionFactory.createLog(ActionType.DOWNVOTE, thread.getAuthorId(), saved.getId());
+        logReflectionFactory.createLog(ActionType.DOWNVOTE, userId, saved.getId());
 
         threadProducer.sendThreadNotificationRequest(saved, "down");
 


### PR DESCRIPTION
This pull request updates the logging behavior in the `ThreadService` class to ensure that the `userId` of the acting user is logged instead of the `thread`'s author ID. This change improves the accuracy of action logs for comments, upvotes, and downvotes.

### Logging behavior updates:

* `addComment` method: Updated the `logReflectionFactory.createLog` call to use the `userId` of the user adding the comment instead of the `thread`'s author ID. (`ThreadService.java`, [ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.javaL136-R136](diffhunk://#diff-122de49d8749248ccbfd55565b771f009150900bfb0eb255bc65f5be7ee44f10L136-R136))
* `upvote` method: Updated the `logReflectionFactory.createLog` call to use the `userId` of the user performing the upvote instead of the `thread`'s author ID. (`ThreadService.java`, [ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.javaL215-R215](diffhunk://#diff-122de49d8749248ccbfd55565b771f009150900bfb0eb255bc65f5be7ee44f10L215-R215))
* `downvote` method: Updated the `logReflectionFactory.createLog` call to use the `userId` of the user performing the downvote instead of the `thread`'s author ID. (`ThreadService.java`, [ThreadService/src/main/java/com/example/reddit/ThreadsService/services/ThreadService.javaL246-R246](diffhunk://#diff-122de49d8749248ccbfd55565b771f009150900bfb0eb255bc65f5be7ee44f10L246-R246))